### PR TITLE
fix(skills): respine Gleam/Lustre skills to e2e type-safety architecture

### DIFF
--- a/skills/frontend-testing/SKILL.md
+++ b/skills/frontend-testing/SKILL.md
@@ -49,7 +49,7 @@ Frontend tests verify **model, update, and behavior** — never CSS classes, Tai
 pub fn initial_order_form_has_empty_lines_test() {
   let model = order_form.init()
   model.lines |> should.equal([])
-  model.is_submitting |> should.equal(False)
+  model.save |> should.equal(submit.SubmitIdle)
 }
 
 // Update logic
@@ -82,7 +82,7 @@ pub fn click_submit_sets_submitting_test() {
     test_app()
     |> simulate.click(on: query.element(query.id("submit-btn")))
     |> simulate.model()
-  model.is_submitting |> should.equal(True)
+  model.save |> should.equal(submit.SubmitSaving)
 }
 
 // Keyboard navigation

--- a/skills/frontend-testing/references/lustre-testing-patterns.md
+++ b/skills/frontend-testing/references/lustre-testing-patterns.md
@@ -42,9 +42,10 @@ pub fn fetch_success_populates_list_test() {
 pub fn fetch_error_sets_error_state_test() {
   let model =
     test_app()
-    |> simulate.message(FetchedOrders(Error("Network error")))
+    // The Msg carries a typed ErrorCode, never a stringly message
+    |> simulate.message(FetchedOrders(Error(RequestTimedOut)))
     |> simulate.model()
-  model.error |> should.equal(Some("Network error"))
+  model.error |> should.equal(Some(RequestTimedOut))
 }
 ```
 
@@ -58,7 +59,7 @@ pub fn fill_form_and_submit_test() {
     |> simulate.input(on: query.element(query.id("name")), value: "Alice")
     |> simulate.click(on: query.element(query.id("submit")))
     |> simulate.model()
-  model.is_submitting |> should.equal(True)
+  model.save |> should.equal(submit.SubmitSaving)
   model.form.email |> should.equal("a@b.com")
 }
 ```

--- a/skills/gleam/references/fundamentals/error-handling.md
+++ b/skills/gleam/references/fundamentals/error-handling.md
@@ -19,28 +19,43 @@
 - **NEVER write `fn(_err) {`** in error handlers — bind and log:
   ```gleam
   // WRONG
-  result.map_error(fn(_) { ServerError("parse failed") })
+  result.map_error(fn(_) { DatabaseError })
 
   // RIGHT
-  result.map_error(fn(err) { ServerError("parse failed: " <> string.inspect(err)) })
+  result.map_error(fn(err) {
+    wisp.log_error("create_product: " <> string.inspect(err))
+    DatabaseError
+  })
   ```
 
 - **Exception**: `Error(_)` is OK when the error type is `Nil` (e.g., `int.parse`, `dict.get`) since there's nothing to inspect. `Ok(_)` to discard success values is also fine.
 
-## Unified Error Handling
+## The Error Contract: Typed Codes, Not Prose
 
-Create a unified error type with HTTP status mapping:
+Errors that cross a boundary (entity → handler → client) are **typed values**, not strings. Two rules keep the channel honest:
+
+1. **No prose baked into the error.** A variant names *what* went wrong (`TitleRequired`, `EmailAlreadyExists`); it does not carry a pre-rendered English sentence. Human-readable, localized text is produced at the *presentation* layer — on the client for UI, in the log line for operators — by mapping the code. The same `EmailAlreadyExists` renders as "E-mail já cadastrado" or "Email already in use" depending on the viewer; bake the English in and you have hard-coded one locale into your domain.
+2. **The client never receives English on the error channel.** The server sends a stable machine **code** (plus any structured data the client needs); the client owns the code → message table.
 
 ```gleam
-pub type AppError {
-  BadRequest(String)           // 400
-  Unauthorized(String)         // 401
-  Forbidden(String)            // 403
-  NotFound(String)             // 404
-  UnprocessableContent(String) // 422
-  InternalServerError(String)  // 500
+// BAD — prose baked into the error; ships one hard-coded locale to the client
+pub type ProductError {
+  ValidationFailed(String)   // Error(ValidationFailed("Title is required"))
+}
+
+// GOOD — payload-free typed codes; the *variant* is the message
+pub type ProductError {
+  NotFound(id: Uuid)         // structured data (an id) is fine; English prose is not
+  TitleRequired
+  TitleTooLong
+  HandleAlreadyTaken
+  DatabaseError              // payload-free; log the raw cause where you catch it
 }
 ```
+
+A variant may carry **structured** data the consumer needs (an id, a count, a limit) — `NotFound(id: Uuid)`, `TooManyItems(limit: Int)`. It must not carry a rendered message string.
+
+> **Why payload-free?** A closed set of typed codes is exhaustively matchable (the compiler finds every `case` when you add a variant — see anti-pattern A9), trivially mappable to an HTTP status, and localizable on the client. A `String` payload is none of these.
 
 ## Philosophy: Errors as Values
 
@@ -48,14 +63,16 @@ Gleam uses `Result` types for error handling. There are no exceptions. Every fun
 
 ## Domain-Specific Errors
 
-For better type safety, create domain-specific error types in your entity modules:
+Create domain-specific error types in your entity modules — as **typed codes**, not message carriers:
 
 ```gleam
 // catalog/product.gleam
 pub type ProductError {
-  NotFound(Uuid)
-  ValidationFailed(String)
-  DatabaseError(String)
+  NotFound(id: Uuid)
+  TitleRequired
+  TitleTooLong
+  HandleAlreadyTaken
+  DatabaseError
 }
 
 // auth/session.gleam
@@ -65,42 +82,49 @@ pub type SessionError {
   Expired
   InvalidToken
 }
+```
 
-// order/order.gleam
-pub type OrderError {
-  NotFound(String)
-  ValidationError(String)
-  DatabaseError(String)
+These are self-documenting and pattern-matched precisely. At the handler boundary, map them to an HTTP status and a wire **code** — never to an English sentence baked in server-side.
+
+## The One Open-String Channel: the Decode Boundary
+
+There is exactly one place a free-form string is legitimate on the error channel: **decoding an untrusted request body or path**, where the offending field name is not known until runtime. Mint a single dedicated variant there:
+
+```gleam
+pub type AppError {
+  // ... typed domain codes ...
+  RequestBodyInvalid(field: String, code: String)   // ONLY at the decode boundary
 }
 ```
 
-These errors are self-documenting and can be pattern-matched precisely.
-At the handler boundary, map domain errors to HTTP responses.
+- `field` is the JSON/path location that failed (`"email"`, `"items.0.qty"`).
+- `code` is a *machine* token (`"required"`, `"not_an_email"`), **not** a sentence.
+
+Mint `RequestBodyInvalid` only inside the `require_json` / body-decode / `path_id` helpers. Everywhere deeper in the stack, use the typed domain codes above. This keeps the open-string surface to a single, auditable boundary.
 
 ## Application Error Type
 
-Create an application-level error type that wraps domain errors and provides cross-cutting concerns:
+Wrap domain errors in one application-level type that also carries the decode-boundary channel and cross-cutting codes:
 
 ```gleam
 // error/error.gleam
 
 import catalog/product
 import auth/session
-import order/order
 
 pub type AppError {
   // Domain error wrappers
   ProductErr(product.ProductError)
   SessionErr(session.SessionError)
-  OrderErr(order.OrderError)
 
-  // Cross-cutting concerns (for cases not covered by domain errors)
-  ValidationErr(String)          // Generic input validation
-  AuthenticationErr(String)      // Auth failures
-  AuthorizationErr(String)       // Permission failures
-  ResourceNotFoundErr(String)    // Generic not found
-  ConflictErr(String)            // Resource conflicts
-  InternalErr(String)            // Unexpected errors
+  // The single open-string channel (decode boundary only):
+  RequestBodyInvalid(field: String, code: String)
+
+  // Cross-cutting typed codes (no String prose):
+  Unauthenticated
+  Forbidden
+  RateLimited
+  Internal
 }
 ```
 
@@ -108,105 +132,77 @@ pub type AppError {
 
 ## Helper Functions
 
+Map each error to (1) an HTTP status and (2) a stable wire **code**. There is deliberately **no `message` helper that returns English** — rendering belongs to the viewer (client or log), not the error module.
+
 ```gleam
-/// Get HTTP status code for an error
+/// HTTP status code for an error
 pub fn to_status_code(error: AppError) -> Int {
   case error {
-    // Domain errors - map to appropriate status
     ProductErr(product.NotFound(_)) -> 404
-    ProductErr(product.ValidationFailed(_)) -> 422
-    ProductErr(product.DatabaseError(_)) -> 500
+    ProductErr(product.TitleRequired) -> 422
+    ProductErr(product.TitleTooLong) -> 422
+    ProductErr(product.HandleAlreadyTaken) -> 409
+    ProductErr(product.DatabaseError) -> 500
     SessionErr(session.InvalidCredentials) -> 401
     SessionErr(session.EmailAlreadyExists) -> 409
     SessionErr(session.Expired) -> 401
     SessionErr(session.InvalidToken) -> 401
-    OrderErr(order.NotFound(_)) -> 404
-    OrderErr(order.ValidationError(_)) -> 422
-    OrderErr(order.DatabaseError(_)) -> 500
-
-    // Cross-cutting errors
-    ValidationErr(_) -> 400
-    AuthenticationErr(_) -> 401
-    AuthorizationErr(_) -> 403
-    ResourceNotFoundErr(_) -> 404
-    ConflictErr(_) -> 409
-    InternalErr(_) -> 500
+    RequestBodyInvalid(_, _) -> 422
+    Unauthenticated -> 401
+    Forbidden -> 403
+    RateLimited -> 429
+    Internal -> 500
   }
 }
 
-/// Extract message from any error variant
-pub fn message(error: AppError) -> String {
+/// Stable machine code for the wire + logs (NOT user-facing prose)
+pub fn to_code(error: AppError) -> String {
   case error {
-    ProductErr(product.NotFound(id)) -> "Product not found: " <> uuid.to_string(id)
-    ProductErr(product.ValidationFailed(msg)) -> msg
-    ProductErr(product.DatabaseError(msg)) -> msg
-    SessionErr(session.InvalidCredentials) -> "Invalid credentials"
-    SessionErr(session.EmailAlreadyExists) -> "Email already exists"
-    SessionErr(session.Expired) -> "Session expired"
-    SessionErr(session.InvalidToken) -> "Invalid token"
-    OrderErr(order.NotFound(msg)) -> msg
-    OrderErr(order.ValidationError(msg)) -> msg
-    OrderErr(order.DatabaseError(msg)) -> msg
-    ValidationErr(msg) -> msg
-    AuthenticationErr(msg) -> msg
-    AuthorizationErr(msg) -> msg
-    ResourceNotFoundErr(msg) -> msg
-    ConflictErr(msg) -> msg
-    InternalErr(msg) -> msg
-  }
-}
-
-/// Get error kind as a string (for logging)
-pub fn kind(error: AppError) -> String {
-  case error {
-    ProductErr(product.NotFound(_)) -> "ProductNotFound"
-    ProductErr(product.ValidationFailed(_)) -> "ProductValidation"
-    ProductErr(product.DatabaseError(_)) -> "ProductDatabase"
-    SessionErr(session.InvalidCredentials) -> "InvalidCredentials"
-    SessionErr(session.EmailAlreadyExists) -> "EmailExists"
-    SessionErr(session.Expired) -> "SessionExpired"
-    SessionErr(session.InvalidToken) -> "InvalidToken"
-    OrderErr(order.NotFound(_)) -> "OrderNotFound"
-    OrderErr(order.ValidationError(_)) -> "OrderValidation"
-    OrderErr(order.DatabaseError(_)) -> "OrderDatabase"
-    ValidationErr(_) -> "Validation"
-    AuthenticationErr(_) -> "Authentication"
-    AuthorizationErr(_) -> "Authorization"
-    ResourceNotFoundErr(_) -> "NotFound"
-    ConflictErr(_) -> "Conflict"
-    InternalErr(_) -> "Internal"
+    ProductErr(product.NotFound(_)) -> "product.not_found"
+    ProductErr(product.TitleRequired) -> "product.title_required"
+    ProductErr(product.TitleTooLong) -> "product.title_too_long"
+    ProductErr(product.HandleAlreadyTaken) -> "product.handle_taken"
+    ProductErr(product.DatabaseError) -> "product.database_error"
+    SessionErr(session.InvalidCredentials) -> "session.invalid_credentials"
+    SessionErr(session.EmailAlreadyExists) -> "session.email_exists"
+    SessionErr(session.Expired) -> "session.expired"
+    SessionErr(session.InvalidToken) -> "session.invalid_token"
+    RequestBodyInvalid(_, _) -> "request_body_invalid"
+    Unauthenticated -> "unauthenticated"
+    Forbidden -> "forbidden"
+    RateLimited -> "rate_limited"
+    Internal -> "internal"
   }
 }
 ```
 
+Match every variant explicitly (anti-pattern A9) — when you add an error, the compiler points you at both helpers.
+
 ## Error Response Module
 
-Create a response handler that converts errors to HTTP responses:
+Convert an error to an HTTP response. The **log** line (for operators) may include English and full detail; the **body** (for the client) carries only the code plus any structured fields.
 
 ```gleam
 // error/response.gleam
 
 import error/error.{type AppError}
 import error/view as error_view
+import gleam/string
 import wisp
 
 pub fn handle(err: AppError) -> wisp.Response {
-  // Log the error (full details for debugging)
-  wisp.log_error(error.kind(err) <> ": " <> error.message(err))
+  // Operators get detail — string.inspect keeps the full typed value
+  wisp.log_error(error.to_code(err) <> ": " <> string.inspect(err))
 
-  // Return appropriate HTTP response (safe message only)
-  let status = error.to_status_code(err)
-  let body = error_view.to_json_string(err)
-
-  wisp.response(status)
+  wisp.response(error.to_status_code(err))
   |> wisp.set_header("content-type", "application/json")
-  |> wisp.string_body(body)
+  |> wisp.string_body(error_view.to_json_string(err))
 }
 ```
 
 ## Error View Module
 
-Serialize errors to JSON (hiding internal details from clients):
+Serialize to JSON as **code + structured fields** — no English:
 
 ```gleam
 // error/view.gleam
@@ -215,69 +211,66 @@ import error/error.{type AppError}
 import gleam/json
 
 pub fn to_json(err: AppError) -> json.Json {
-  json.object([
-    #("error", json.string(safe_message(err))),
-    #("code", json.int(error.to_status_code(err))),
-  ])
+  json.object([#("code", json.string(error.to_code(err))), ..extra_fields(err)])
 }
 
 pub fn to_json_string(err: AppError) -> String {
   to_json(err) |> json.to_string
 }
 
-/// Return user-safe message (no internal details)
-fn safe_message(err: AppError) -> String {
+/// Only the structured data a client needs to localize or act — never prose.
+fn extra_fields(err: AppError) -> List(#(String, json.Json)) {
   case err {
-    // Domain errors - provide specific but safe messages
-    error.ProductErr(product.NotFound(_)) -> "Product not found"
-    error.ProductErr(product.ValidationFailed(msg)) -> msg
-    error.ProductErr(product.DatabaseError(_)) -> "Database error"
-    error.SessionErr(session.InvalidCredentials) -> "Invalid credentials"
-    error.SessionErr(session.EmailAlreadyExists) -> "Email already in use"
-    error.SessionErr(session.Expired) -> "Session expired"
-    error.SessionErr(session.InvalidToken) -> "Invalid token"
-    error.OrderErr(order.NotFound(_)) -> "Order not found"
-    error.OrderErr(order.ValidationError(msg)) -> msg
-    error.OrderErr(order.DatabaseError(_)) -> "Database error"
-
-    // Cross-cutting errors
-    error.ValidationErr(msg) -> msg
-    error.AuthenticationErr(_) -> "Authentication required"
-    error.AuthorizationErr(_) -> "Access denied"
-    error.ResourceNotFoundErr(msg) -> msg
-    error.ConflictErr(msg) -> msg
-    error.InternalErr(_) -> "An unexpected error occurred"
+    error.RequestBodyInvalid(field, code) -> [
+      #("field", json.string(field)),
+      #("detail", json.string(code)),
+    ]
+    _ -> []
   }
 }
 ```
 
+On the client, decode `code` back into a typed `ErrorCode` and render the localized message — the client owns the locale table:
+
+```gleam
+// client side — wire code -> typed code -> localized text
+fn message_for(code: ErrorCode, lang: Language) -> String {
+  case code, lang {
+    ProductTitleRequired, Portuguese -> "Título é obrigatório"
+    ProductTitleRequired, English -> "Title is required"
+    // ...
+  }
+}
+```
+
+The server shipped no English; the client owns every user-facing string.
+
 ## Error Propagation Pattern
 
-Use `result.try` to chain operations that might fail:
+Use `result.try` to chain operations that might fail. Mint `RequestBodyInvalid` at the decode boundary; map domain errors with their wrappers deeper in.
 
 ```gleam
 import gleam/result
 
 pub fn process_request(req: Request, db: Connection) -> Response {
   let result = {
-    // Parse and validate input
+    // Decode boundary — the one place an open-string code is legitimate
     use user_id <- result.try(
       uuid.from_string(req.user_id)
-      |> result.replace_error(error.ValidationErr("Invalid user ID"))
+      |> result.replace_error(error.RequestBodyInvalid("user_id", "not_a_uuid"))
     )
 
     use tenant_id <- result.try(
       uuid.from_string(req.tenant_id)
-      |> result.replace_error(error.ValidationErr("Invalid tenant ID"))
+      |> result.replace_error(error.RequestBodyInvalid("tenant_id", "not_a_uuid"))
     )
 
-    // Call entity layer - returns domain error
+    // Entity layer — returns a typed domain error
     use data <- result.try(
       product.get(db, user_id, tenant_id)
       |> result.map_error(error.ProductErr)
     )
 
-    // Transform result
     Ok(view.to_json(data))
   }
 
@@ -292,7 +285,7 @@ pub fn process_request(req: Request, db: Connection) -> Response {
 
 ### Handler Layer
 
-HTTP handlers parse requests, call entity functions, and map errors to HTTP responses.
+HTTP handlers parse requests, call entity functions, and map errors to HTTP responses. Decode failures become `RequestBodyInvalid`; domain failures keep their typed codes.
 
 ```gleam
 // catalog/handler.gleam
@@ -302,13 +295,17 @@ pub fn create(req: Request, db: Connection, tenant_id: String) -> Response {
   let result = {
     use tid <- result.try(
       uuid.from_string(tenant_id)
-      |> result.replace_error(error.ValidationErr("Invalid tenant ID"))
+      |> result.replace_error(error.RequestBodyInvalid("tenant_id", "not_a_uuid"))
     )
+    // A real request_body helper maps each decode.DecodeError to a precise
+    // field path + machine code; minted only here, at the decode boundary.
     use data <- result.try(
       decode.run(json_body, view.decoder())
-      |> result.replace_error(error.ValidationErr("Invalid request body"))
+      |> result.map_error(fn(_errs) {
+        error.RequestBodyInvalid(field: "body", code: "invalid")
+      })
     )
-    // Call entity function - map domain error to app error
+    // Call entity function — map domain error to app error
     product.create(db, tid, data)
     |> result.map_error(error.ProductErr)
   }
@@ -326,103 +323,92 @@ pub fn create(req: Request, db: Connection, tenant_id: String) -> Response {
 
 ### Entity Layer
 
-Entity modules contain types, pure functions, and database operations. They return domain-specific errors:
+Entity modules contain types, pure functions, and database operations. They return **typed domain codes** — and log the raw cause where they catch it, so the payload-free `DatabaseError` stays code-only:
 
 ```gleam
 // catalog/product.gleam
 pub type ProductError {
-  NotFound(Uuid)
-  ValidationFailed(String)
-  DatabaseError(String)
+  NotFound(id: Uuid)
+  TitleRequired
+  TitleTooLong
+  HandleAlreadyTaken
+  DatabaseError
 }
 
-/// Create a product - returns domain error
+/// Create a product — returns a typed domain code
 pub fn create(db: pog.Connection, tenant_id: Uuid, data: CreateRequest)
   -> Result(sql.CreateProductRow, ProductError) {
-  // Validation
   case string.is_empty(data.title) {
-    True -> Error(ValidationFailed("Title is required"))
+    True -> Error(TitleRequired)
     False -> {
       case sql.create_product(db, tenant_id, data.title, data.handle) {
-        Ok(returned) -> extract_first(returned)
-        Error(_) -> Error(DatabaseError("Database error"))
+        Ok(returned) -> extract_first(returned, tenant_id)
+        Error(err) -> {
+          wisp.log_error("sql.create_product: " <> string.inspect(err))
+          Error(DatabaseError)
+        }
       }
     }
   }
 }
 
-pub fn get_by_id(db: pog.Connection, id: Uuid, tenant_id: Uuid)
-  -> Result(sql.GetProductRow, ProductError) {
-  case sql.get_product(db, id, tenant_id) {
-    Ok(returned) -> extract_first(returned)
-    Error(_) -> Error(DatabaseError("Database error"))
-  }
-}
-
-fn extract_first(returned: pog.Returned(a)) -> Result(a, ProductError) {
+fn extract_first(returned: pog.Returned(a), id: Uuid) -> Result(a, ProductError) {
   case returned.rows {
     [row] -> Ok(row)
-    [] -> Error(NotFound(uuid.v7()))  // or pass the actual ID
-    _ -> Error(DatabaseError("Unexpected result"))
+    [] -> Error(NotFound(id))
+    _ -> Error(DatabaseError)
   }
 }
 ```
 
 ## Converting External Errors
 
-When integrating with external services that have their own error types:
+When integrating with external services that have their own error types, map them to your typed codes (never pass their strings through to the client):
 
 ```gleam
 // Map external error to app error
 fn external_to_error(e: ExternalError) -> error.AppError {
   case e {
-    external.NetworkError(msg) -> error.InternalErr("Network error: " <> msg)
-    external.NotFound -> error.ResourceNotFoundErr("External resource not found")
-    external.RateLimited -> error.InternalErr("Rate limited by external service")
-    external.Unauthorized -> error.AuthenticationErr("External service authentication failed")
-  }
-}
-
-// Usage
-pub fn fetch_external_data(client: Client, id: String)
-  -> Result(Data, error.AppError) {
-  case external_service.get(client, id) {
-    Ok(data) -> Ok(data)
-    Error(e) -> Error(external_to_error(e))
+    external.NetworkError(_) -> error.Internal
+    external.NotFound -> error.ProductErr(product.NotFound(uuid.v7()))
+    external.RateLimited -> error.RateLimited
+    external.Unauthorized -> error.Unauthenticated
   }
 }
 ```
 
 ## Best Practices
 
-### 1. Be Specific with Error Messages
+### 1. Name the failure, don't describe it
 
 ```gleam
-// Bad
-Error(error.ValidationErr("Invalid input"))
+// Bad — prose on the error channel
+Error(ValidationFailed("Email must be a valid email address"))
 
-// Good
-Error(error.ValidationErr("Email must be a valid email address"))
+// Good — a typed code; the client renders the locale-specific message
+Error(SessionErr(session.InvalidCredentials))
+// At the decode boundary only:
+Error(error.RequestBodyInvalid("email", "not_an_email"))
 ```
 
 ### 2. Don't Expose Internal Details
 
 ```gleam
-// Bad - exposes internal structure
-Error(error.InternalErr("pog.QueryError: constraint violation"))
+// Bad — leaks internal structure to the client
+Error(error.RequestBodyInvalid("body", "pog.QueryError: constraint violation"))
 
-// Good - generic message
-Error(error.InternalErr("Database error"))
-// Log the actual error for debugging
+// Good — a payload-free code; log the real cause where you catch it
+Error(Internal)
+// wisp.log_error("...: " <> string.inspect(raw_error))
 ```
 
 ### 3. Use Appropriate Error Types
 
 ```gleam
-// Wrong - using generic error for domain concept
-Error(error.InternalErr("User not found"))
+// Wrong — generic code for a domain concept
+Error(error.Internal)
 
-// Correct - use domain error
+// Correct — the specific domain code
 Error(error.ProductErr(product.NotFound(id)))
 ```
 
@@ -438,6 +424,6 @@ use _ <- result.try(check_permission(permissions, "create"))
 
 ### 5. Log Errors at the Right Level
 
-- **Handler**: Log all errors before returning HTTP response
-- **Entity**: Log significant business rule violations
-- **SQL/View**: Don't log (let handler handle it)
+- **Handler**: Log the typed code + `string.inspect` before returning the HTTP response.
+- **Entity**: Log the raw cause where a payload-free code (e.g. `DatabaseError`) is minted, so the code stays prose-free upstream.
+- **SQL/View**: Don't log (let the handler/entity boundary handle it).

--- a/skills/gleam/references/fundamentals/type-design.md
+++ b/skills/gleam/references/fundamentals/type-design.md
@@ -299,6 +299,35 @@ pub type CustomerForm {
 }
 ```
 
+### Async Page State: RemoteData
+
+A page that loads data over the network has four states, not a `Bool` + `Option`. Model them as one union so the loading flag and the payload can never disagree.
+
+```gleam
+// BAD — detached: is_loading can be True while data is Some, or both empty
+pub type ProductsPage {
+  ProductsPage(
+    is_loading: Bool,
+    data: Option(List(Product)),
+    error: Option(String),
+  )
+}
+
+// GOOD — the payload lives *inside* the loaded variant
+pub type RemoteData(value, error) {
+  RemoteIdle
+  RemoteLoading
+  RemoteLoaded(value)
+  RemoteFailed(error)
+}
+
+pub type Model {
+  Model(products: RemoteData(List(Product), ErrorCode))
+}
+```
+
+Guard behaviorally with predicates (`remote.is_loading`, `remote.is_failed`) rather than reaching into the variant in the view. The failure carries a typed `ErrorCode` (see `error-handling.md`), never a stringly message. A form's *save* lifecycle uses the same shape — see `Submit` in the lustre skill's `advanced-mvu-forms.md`.
+
 ### Unified Validation Module
 
 For domains with multiple validated types, create a unified validation module:

--- a/skills/lustre/CONTEXT.md
+++ b/skills/lustre/CONTEXT.md
@@ -10,7 +10,7 @@ Inherits: `skills/CONTEXT.md`.
 lustre/
 ├── SKILL.md                         # Main prompt with decision trees
 └── references/                      # JavaScript target — Lustre
-    ├── advanced-mvu-forms.md    # FormState, FieldState, parameterization
+    ├── advanced-mvu-forms.md    # Save lifecycle (Submit), FieldState, parameterization
     ├── lustre-core.md           # MVU architecture, state, messages
     ├── lustre-effects.md        # Effects, paint cycle
     ├── lustre-routing.md        # SPA routing (modem)
@@ -46,5 +46,5 @@ lustre/
 | Common Lustre gotchas                    | `lustre-gotchas.md`                             |
 
 ## Common Lustre Gotchas
-- **Prefer sum types over `Bool` fields in model state.** Aligns with MVU conventions. Use `FormState(data)` for forms.
+- **Prefer sum types over `Bool` fields in model state.** Aligns with MVU conventions. For a form, the model owns its data and carries a sibling `save: Submit` (`SubmitIdle | SubmitSaving | SubmitSaved | SubmitFailed(err)`); for a page load, use `RemoteData`. Never a `saving: Bool`.
 - **Never pass `Model` to Effects.** Extract the needed primitives in the `update` loop.

--- a/skills/lustre/SKILL.md
+++ b/skills/lustre/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lustre
-description: Gleam frontend development skill targeting JavaScript. Covers Lustre 5.x, MVU Architecture, Advanced Forms (FormState/FieldState), UI Patterns, SPA Routing (modem), and HTTP requests (rsvp). Use when building UI or working in client/src/.
+description: Gleam frontend development skill targeting JavaScript. Covers Lustre 5.x, MVU Architecture, Advanced Forms (save-lifecycle state machines/FieldState), UI Patterns, SPA Routing (modem), and HTTP requests (rsvp). Use when building UI or working in client/src/.
 ---
 
 # Lustre & Frontend Best Practices
@@ -33,6 +33,6 @@ Skill for Gleam frontend development using Lustre. **Read the relevant reference
 
 ## Core Frontend Principles
 
-1. **Make Impossible States Impossible** — Prefer sum types over Bools. Especially important for async states: `Idle | Submitting | Failed(err)`.
+1. **Make Impossible States Impossible** — Prefer sum types over Bools. Especially for async lifecycles: a form's save is `SubmitIdle | SubmitSaving | SubmitSaved | SubmitFailed(err)` (the model owns its data + a sibling `save` field); a page load is `RemoteData`. Never a `Bool` flag beside the data.
 2. **Parse, Don't Validate** — Use `FieldState(v, e)` to wrap invalid UI state, rather than dictionaries.
 3. **Dumb Effects** — Effects should be pure executors of I/O. Never pass the `Model` into an effect function.

--- a/skills/lustre/references/advanced-mvu-forms.md
+++ b/skills/lustre/references/advanced-mvu-forms.md
@@ -72,38 +72,67 @@ fn build_request(form: Form) -> Result(UpdateAddressRequest, Nil) {
 
 ## 3. Form-Level State Machines
 
-A form is a state machine. It is either `Idle` (editable), `Submitting` (locked), or `Failed` (editable, showing server error). 
+A form's **save lifecycle** is a state machine: it is either `SubmitIdle` (editable), `SubmitSaving` (locked, in flight), `SubmitSaved` (done), or `SubmitFailed(ErrorCode)` (editable again, showing the server error). The model **owns its form-data record** and carries a *sibling* `save` field holding that lifecycle. The **variant is the flag** — the saving status is never a `Bool`.
 
-**BAD (Detached Booleans):**
+**BAD (the "boolean twin"):**
 ```gleam
-pub type CustomerForm {
-  CustomerForm(
-    name: String,
-    saving: Bool, // Detached! User can type while Saving.
-  )
+pub type CustomerDialog {
+  CustomerDialog(
+    data: CustomerFormData,
+    saving: Bool,              // detached! user can type while saving
+    error: Option(ErrorCode),  // 8 representable states, most invalid:
+  )                            // saving=True AND error=Some AND already saved?
 }
 ```
 
-**GOOD (Wrapped FormState):**
-Wrap the form data in a `FormState` machine (typically found in `shared/lib/form_state`).
+A `Bool` + `Option` pair encodes impossible combinations and lets edits land mid-flight.
+
+**GOOD (sibling save-lifecycle field):**
+The model owns its data; one sibling `save` field carries the whole lifecycle as a sum type.
 
 ```gleam
-pub type FormState(data) {
-  Idle(data: data)
-  Submitting(data: data)
-  Failed(data: data, error: ErrorCode)
+pub type Submit {
+  SubmitIdle
+  SubmitSaving
+  SubmitSaved
+  SubmitFailed(ErrorCode)  // the typed error channel — see error-handling.md
 }
 
 pub type CustomerDialog {
   CustomerDialog(
-    form_state: FormState(CustomerFormData), // Wraps the data
+    data: CustomerFormData,  // the model owns its form-data record
+    save: Submit,            // the whole save lifecycle in one field
   )
 }
 ```
 
-*Benefit:* 
-1. **Updates:** In `update.gleam`, `form_state.map` ignores mutations if the state is `Submitting`. Impossible to mutate data during flight.
-2. **Views:** In `view.gleam`, you check `form_state.is_submitting(state)`. If `True`, you pass `disabled: True` down to all form inputs automatically.
+*Benefit:*
+1. **Updates:** In `update.gleam`, a `UserTyped…` message that arrives while the save is in flight is simply dropped — no edit lands mid-flight. Guard **behaviorally** with a predicate, never by hard-coding a stored `Bool`.
+2. **Views:** In `view.gleam`, predicates (`submit.is_saving`, `submit.is_failed`) drive `disabled:` on every input and surface the `SubmitFailed(ErrorCode)` payload as the form-level error.
+
+Guard on **behavior**, not structure:
+```gleam
+// view.gleam — disable inputs while the save is in flight
+let locked = submit.is_saving(model.save)
+html.input([attribute.disabled(locked), ..attrs])
+
+// update.gleam — ignore edits during flight
+case submit.is_saving(model.save) {
+  True -> #(model, effect.none())                       // drop the edit
+  False -> #(set_field(model, field, value), effect.none())
+}
+```
+
+**Page loads work the same way.** Model an async page payload as `RemoteData` — the loaded value lives *inside* the `RemoteLoaded` variant — and guard with `remote.is_loading`, never an `is_loading: Bool` beside an `Option(data)`. (See `RemoteData` in `gleam/references/fundamentals/type-design.md`.)
+
+> **aboio reference implementation — the `spine` lib.** In the aboio house stack, `Submit` and `RemoteData` ship in the vendored `spine` lib, each re-bound in the client as an `ErrorCode`-specialized type alias (`state/submit`, `state/remote`). The pattern above is what matters — if your project doesn't vendor `spine`, define the equivalent unions yourself.
+>
+> **Import recipe (aboio stack).** The `state/*` modules expose only the **type aliases** (`type Submit`, `type RemoteData`); the **constructors and predicates** (`SubmitSaving`, `submit.is_saving`, `remote.is_loading`) live in `spine/submit` / `spine/remote`. The two `submit` modules collide on the bare name, so a file that *both* annotates a field and calls predicates needs:
+> ```gleam
+> import spine/submit                   // constructors + predicates: submit.SubmitSaving, submit.is_saving
+> import state/submit as state_submit   // the ErrorCode-bound alias, for annotations only
+> ```
+> A model-type file that only annotates can use `import state/submit.{type Submit}` alone.
 
 ---
 


### PR DESCRIPTION
## Why

The Gleam/Lustre skills taught the **pre-Spine** MVU-forms and error-channel patterns this stack has since deleted. Copying their examples now produces compile errors against current code. This is the skills-repo counterpart of kafka's Batch 22 (PR #4560), which fixed the same drift in kafka's own docs.

Because **aboio-skills is a reusable library** (it does *not* ship the `spine` lib), the rewrite teaches the **portable principle** and names `spine`/`state/submit`/`RemoteData` only in a clearly-labelled "aboio reference implementation" aside. No kafka issue numbers, `client/src/...` paths, or `MVU_CANON.md` references leaked in.

## What changed

| File | Fix |
|------|-----|
| `skills/lustre/references/advanced-mvu-forms.md` | §3 rewritten: the deleted generic `FormState(data)` wrapper (`Idle\|Submitting\|Failed` + `form_state.map`/`is_submitting`) → **model owns its data + sibling `save: Submit`** (`SubmitIdle\|SubmitSaving\|SubmitSaved\|SubmitFailed(ErrorCode)`), behavioral predicate guards, `RemoteData` page-load counterpart, and the `spine`/`state-submit` import-recipe aside. |
| `skills/lustre/SKILL.md` + `CONTEXT.md` | Drop `FormState(data)` from the description, async-states principle, layout note, and gotcha; point to `save: Submit` / `RemoteData`. |
| `skills/gleam/references/fundamentals/error-handling.md` | Generalized to the **typed-code contract**: payload-free error variants (no prose baked in), the single decode-boundary open-string channel `RequestBodyInvalid(field, code)`, and **code-not-English** on the wire (client owns the locale table). Drops the `safe_message` English channel and stringly `ValidationFailed`/`ValidationErr` teaching. |
| `skills/gleam/references/fundamentals/type-design.md` | Add the `RemoteData` subsection that `conventions.md` already pointed to (was a dangling reference). |
| `skills/frontend-testing/{SKILL.md, references/lustre-testing-patterns.md}` | Replace `model.is_submitting: Bool` assertions with the `save: Submit` variant; type the stale stringly page-load error. |

## Verification

- Re-grepped the dead-pattern surface (`FormState`/`form_state`/`is_submitting`/`ValidationFailed`/…): the only remaining hits are **labelled BAD counter-examples** in `error-handling.md`.
- Adversarial review (against the corrected kafka exemplar + canon) found **no must-fix issues** — import recipe verified correct (not inverted), no kafka-internal leaks, no stale pattern taught as GOOD.

## Not included

The 4 in-progress `skills/lustre/references/{lustre-core,lustre-events,lustre-http,lustre-ui-patterns}.md` edits that were already in the working tree are **intentionally left out** of this PR — they are separate, orthogonal work (state accessors, blur validation, optional-field decoding, sprout table) and are preserved uncommitted.